### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/.github/workflows/Action-py-black-formatter.yml
+++ b/.github/workflows/Action-py-black-formatter.yml
@@ -17,7 +17,7 @@ jobs:
         id: action_black
         # 현재 디렉토리의 모든 파일을 대상으로 포매팅을 수행
         with:
-          black_args: ". --check --diff --fail_on_error"
+          black_args: ". --check --diff"
       - name: Create Pull Request
       # 포매팅이 필요한 경우에만 Pull Request를 생성
         if: steps.action_black.outputs.is_formatted == 'true'

--- a/.github/workflows/Action-py-black-formatter.yml
+++ b/.github/workflows/Action-py-black-formatter.yml
@@ -1,33 +1,33 @@
-# 워크플로의 이름을 정의
-name: black-action
-# 초기는 push, PR 모두 해당하게 지정
-## PR 할 때마다 시간이 조금 걸리는 이슈있음
-## 추후 효율적인 방법으로 수정 예정
-on: [push, pull_request]
-jobs:
-  linter_name:
-    name: runner / black
-    runs-on: ubuntu-latest
-    steps:
-    # 현재 리포지토리를 체크아웃
-      - uses: actions/checkout@v2
-      - name: Check files using the black formatter
-      # rickstaa/action-black 액션을 사용하여 black 포매터를 실행
-        uses: rickstaa/action-black@v1
-        id: action_black
-        # 현재 디렉토리의 모든 파일을 대상으로 포매팅을 수행
-        with:
-          black_args: ". --check --diff"
-      - name: Create Pull Request
-      # 포매팅이 필요한 경우에만 Pull Request를 생성
-        if: steps.action_black.outputs.is_formatted == 'true'
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.TOKEN }}
-          title: "Format Python code with psf/black push"
-          commit-message: ":art: Format Python code with psf/black"
-          body: |
-            There appear to be some python formatting errors in ${{ github.sha }}. This pull request
-            uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
-          base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
-          branch: actions/black
+# # 워크플로의 이름을 정의
+# name: black-action
+# # 초기는 push, PR 모두 해당하게 지정
+# ## PR 할 때마다 시간이 조금 걸리는 이슈있음
+# ## 추후 효율적인 방법으로 수정 예정
+# on: [push, pull_request]
+# jobs:
+#   linter_name:
+#     name: runner / black
+#     runs-on: ubuntu-latest
+#     steps:
+#     # 현재 리포지토리를 체크아웃
+#       - uses: actions/checkout@v2
+#       - name: Check files using the black formatter
+#       # rickstaa/action-black 액션을 사용하여 black 포매터를 실행
+#         uses: rickstaa/action-black@v1
+#         id: action_black
+#         # 현재 디렉토리의 모든 파일을 대상으로 포매팅을 수행
+#         with:
+#           black_args: ". --check --diff"
+#       - name: Create Pull Request
+#       # 포매팅이 필요한 경우에만 Pull Request를 생성
+#         if: steps.action_black.outputs.is_formatted == 'true'
+#         uses: peter-evans/create-pull-request@v3
+#         with:
+#           token: ${{ secrets.TOKEN }}
+#           title: "Format Python code with psf/black push"
+#           commit-message: ":art: Format Python code with psf/black"
+#           body: |
+#             There appear to be some python formatting errors in ${{ github.sha }}. This pull request
+#             uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
+#           base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
+#           branch: actions/black

--- a/.github/workflows/Action-py-black-formatter.yml
+++ b/.github/workflows/Action-py-black-formatter.yml
@@ -17,7 +17,7 @@ jobs:
         id: action_black
         # 현재 디렉토리의 모든 파일을 대상으로 포매팅을 수행
         with:
-          black_args: "."
+          black_args: ". --check --diff --fail_on_error"
       - name: Create Pull Request
       # 포매팅이 필요한 경우에만 Pull Request를 생성
         if: steps.action_black.outputs.is_formatted == 'true'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,10 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -8,3 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
+        with:
+          options: "--check --verbose"
+          src: "./src"
+          version: "~= 22.0"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,5 +10,4 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
-          src: "./src"
           version: "~= 22.0"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,7 +1,11 @@
 # 워크플로 이름 
 name: black-action
-# push or PR 일 때 실행
-on: pull_request
+# develop branch 로 push 했을 때에만 작동하도록 
+on:
+  push:
+    branches:
+      - 'main'
+
 jobs:
   linter_name:
     name: runner / black

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,4 +1,5 @@
 name: black-action
+
 on:
   push:
     branches:
@@ -11,20 +12,35 @@ jobs:
   linter_name:
     name: runner / black
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
-      - name: Check files using the black formatter
-        uses: rickstaa/action-black@v1
-        id: action_black
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          black_args: "."
-      - name: Add comment to Pull Request
-        if: steps.action_black.outputs.is_formatted == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          python-version: 3.9
+
+      - name: Install black
+        run: pip install black
+
+      - name: Check files using the black formatter
+        id: action_black
         run: |
-          echo "::set-env name=INPUT_TOKEN::${{ secrets.TOKEN }}"
-          echo "::set-env name=INPUT_REPOSITORY::${{ github.repository }}"
-          echo "::set-env name=INPUT_PULL_REQUEST_NUMBER::${{ github.event.pull_request.number }}"
-          echo "::set-env name=INPUT_COMMENT::There appear to be some Python formatting errors in ${{ github.sha }}. This pull request uses the [psf/black](https://github.com/psf/black) formatter to fix these issues."
-          npx peter-evans/create-or-update-comment@v1
+          black_args=$(black --check --diff .)
+          if [[ -n $black_args ]]; then
+            echo "::set-output name=is_formatted::false"
+            echo "Code formatting issues found. Here are the suggested changes:"
+            echo "$black_args"
+            exit 1
+          else
+            echo "::set-output name=is_formatted::true"
+          fi
+
+      - name: Add comment to Pull Request
+        if: steps.action_black.outputs.is_formatted == 'false'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            There appear to be some Python formatting errors in ${{ github.sha }}.
+            This pull request uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -29,4 +29,6 @@ jobs:
             uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
           base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
           branch: actions/black
-          run: exit 1
+      - name: Exit Workflow
+        if: steps.action_black.outputs.is_formatted == 'true'
+        run: exit 1

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,13 +1,27 @@
-name: Lint
-
-on: [push, pull_request]
+name: black-action
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  lint:
+  linter_name:
+    name: runner / black
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: psf/black@stable
+      - uses: actions/checkout@v2
+      - name: Check files using the black formatter
+        uses: rickstaa/action-black@v1
+        id: action_black
         with:
-          options: "--check --verbose"
-          version: "~= 22.0"
+          black_args: "."
+      - name: Add comment to Pull Request
+        if: steps.action_black.outputs.is_formatted == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            There appear to be some Python formatting errors in ${{ github.sha }}.
+            This pull request uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,18 +1,30 @@
 name: black-action
+
 on: [push, pull_request]
+
 jobs:
   linter_name:
     name: runner / black
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
+
       - name: Check files using the black formatter
         uses: rickstaa/action-black@v1
         id: action_black
         with:
           black_args: "."
+
+      - name: Validate black formatting
+        run: |
+          if [ "${{ steps.action_black.outputs.is_formatted }}" != "true" ]; then
+            echo "::error::Black formatting check failed. Please format your code."
+            exit 1
+          fi
+
       - name: Create Pull Request
-        if: steps.action_black.outputs.is_formatted == 'true'
+        if: steps.action_black.outputs.is_formatted != 'true'
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.TOKEN }}
@@ -23,3 +35,22 @@ jobs:
             uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
           base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
           branch: actions/black
+
+          draft: true # Make the pull request a draft
+
+          maintainers_can_modify: false # Prevent maintainers from modifying the pull request
+
+          draft_message: |
+            ⚠️ **Warning: This pull request has code formatting issues.**
+
+            The Python code in this pull request does not comply with the black code formatter.
+
+            To fix the formatting issues, please follow these steps:
+            1. Install black: `pip install black`
+            2. Run black on the code: `black .`
+            3. Commit the changes: `git commit -am "Fix code formatting"`
+            4. Push the changes to the branch: `git push origin ${GITHUB_REF}`
+
+            Once the code formatting issues are fixed, this pull request will be automatically updated.
+
+          labels: code-formatting

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -27,18 +27,15 @@ jobs:
       - name: Check files using the black formatter
         id: action_black
         run: |
-          black_args=$(black --check --diff .)
+          black_args=$(black --check --diff . || true)
           if [[ -n $black_args ]]; then
-            echo "::set-output name=is_formatted::false"
-            echo "Code formatting issues found. Here are the suggested changes:"
+            echo "::error::Code formatting issues found. Here are the suggested changes:"
             echo "$black_args"
             exit 1
-          else
-            echo "::set-output name=is_formatted::true"
           fi
 
       - name: Add comment to Pull Request
-        if: steps.action_black.outputs.is_formatted == 'false'
+        if: steps.action_black.outcome == 'failure'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Check files using the black formatter
         id: action_black
         run: |
-          black_args=$(black --check --diff . || true)
-          if [[ -n $black_args ]]; then
+          black_args=$(black --check --diff . 2>&1)
+          if [[ $? -ne 0 ]]; then
             echo "::error::Code formatting issues found. Here are the suggested changes:"
             echo "$black_args"
             exit 1

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,30 +1,24 @@
+# 워크플로 이름 
 name: black-action
-
+# push or PR 일 때 실행
 on: [push, pull_request]
-
 jobs:
   linter_name:
     name: runner / black
     runs-on: ubuntu-latest
-
     steps:
+    # 현재 리포 체크아웃
       - uses: actions/checkout@v2
-
       - name: Check files using the black formatter
+      # rickstaa/action-black 액션을 사용
         uses: rickstaa/action-black@v1
         id: action_black
         with:
+        # 모든 파일을 대상으로 포매팅을 수행
           black_args: "."
-
-      - name: Validate black formatting
-        run: |
-          if [ "${{ steps.action_black.outputs.is_formatted }}" != "true" ]; then
-            echo "::error::Black formatting check failed. Please format your code."
-            exit 1
-          fi
-
       - name: Create Pull Request
-        if: steps.action_black.outputs.is_formatted != 'true'
+      # 수정해야 할 것이 있다면 PR 생성 ( 기존 Branch로 보내는 PR ) 
+        if: steps.action_black.outputs.is_formatted == 'true'
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.TOKEN }}
@@ -35,22 +29,3 @@ jobs:
             uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
           base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
           branch: actions/black
-
-          draft: true # Make the pull request a draft
-
-          maintainers_can_modify: false # Prevent maintainers from modifying the pull request
-
-          draft_message: |
-            ⚠️ **Warning: This pull request has code formatting issues.**
-
-            The Python code in this pull request does not comply with the black code formatter.
-
-            To fix the formatting issues, please follow these steps:
-            1. Install black: `pip install black`
-            2. Run black on the code: `black .`
-            3. Commit the changes: `git commit -am "Fix code formatting"`
-            4. Push the changes to the branch: `git push origin ${GITHUB_REF}`
-
-            Once the code formatting issues are fixed, this pull request will be automatically updated.
-
-          labels: code-formatting

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,7 +1,7 @@
 # 워크플로 이름 
 name: black-action
 # push or PR 일 때 실행
-on: [push, pull_request]
+on: pull_request
 jobs:
   linter_name:
     name: runner / black

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,10 +1,25 @@
-name: Lint
-
+name: black-action
 on: [push, pull_request]
-
 jobs:
-  lint:
+  linter_name:
+    name: runner / black
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: psf/black@stable
+      - uses: actions/checkout@v2
+      - name: Check files using the black formatter
+        uses: rickstaa/action-black@v1
+        id: action_black
+        with:
+          black_args: "."
+      - name: Create Pull Request
+        if: steps.action_black.outputs.is_formatted == 'true'
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.TOKEN }}
+          title: "Format Python code with psf/black push"
+          commit-message: ":art: Format Python code with psf/black"
+          body: |
+            There appear to be some python formatting errors in ${{ github.sha }}. This pull request
+            uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
+          base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
+          branch: actions/black

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           token: ${{ secrets.TOKEN }}
           title: "Format Python code with psf/black push"
-          commit-message: ":art: Format Python code with psf/black"
+          commit-message: "Modify Format Python code with psf/black"
           body: |
             There appear to be some python formatting errors in ${{ github.sha }}. This pull request
             uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,43 +1,10 @@
-name: black-action
+name: Lint
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request]
 
 jobs:
-  linter_name:
-    name: runner / black
+  lint:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: Install black
-        run: pip install black
-
-      - name: Check files using the black formatter
-        id: action_black
-        run: |
-          black_args=$(black --check --diff . 2>&1)
-          if [[ $? -ne 0 ]]; then
-            echo "::error::Code formatting issues found. Here are the suggested changes:"
-            echo "$black_args"
-            exit 1
-          fi
-
-      - name: Add comment to Pull Request
-        if: steps.action_black.outcome == 'failure'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          message: |
-            There appear to be some Python formatting errors in ${{ github.sha }}.
-            This pull request uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -29,3 +29,4 @@ jobs:
             uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
           base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
           branch: actions/black
+          run: exit 1

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -20,8 +20,11 @@ jobs:
           black_args: "."
       - name: Add comment to Pull Request
         if: steps.action_black.outputs.is_formatted == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          message: |
-            There appear to be some Python formatting errors in ${{ github.sha }}.
-            This pull request uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          echo "::set-env name=INPUT_TOKEN::${{ secrets.TOKEN }}"
+          echo "::set-env name=INPUT_REPOSITORY::${{ github.repository }}"
+          echo "::set-env name=INPUT_PULL_REQUEST_NUMBER::${{ github.event.pull_request.number }}"
+          echo "::set-env name=INPUT_COMMENT::There appear to be some Python formatting errors in ${{ github.sha }}. This pull request uses the [psf/black](https://github.com/psf/black) formatter to fix these issues."
+          npx peter-evans/create-or-update-comment@v1

--- a/.github/workflows/black_dog.yml
+++ b/.github/workflows/black_dog.yml
@@ -1,16 +1,16 @@
-name: black-action
-on: [push, pull_request]
-jobs:
-  linter_name:
-    name: runner / black
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Check files using the black formatter
-        uses: datadog/action-py-black-formatter@v2.1
-        id: action_black
-      - name: Annotate diff changes using reviewdog
-        if: steps.action_black.outputs.is_formatted == 'true'
-        uses: reviewdog/action-suggester@v1
-        with:
-          tool_name: blackfmt
+# name: black-action
+# on: [push, pull_request]
+# jobs:
+#   linter_name:
+#     name: runner / black
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - name: Check files using the black formatter
+#         uses: datadog/action-py-black-formatter@v2.1
+#         id: action_black
+#       - name: Annotate diff changes using reviewdog
+#         if: steps.action_black.outputs.is_formatted == 'true'
+#         uses: reviewdog/action-suggester@v1
+#         with:
+#           tool_name: blackfmt

--- a/.github/workflows/black_dog.yml
+++ b/.github/workflows/black_dog.yml
@@ -1,18 +1,16 @@
-name: reviewdog
-on: [pull_request]
+name: black-action
+on: [push, pull_request]
 jobs:
   linter_name:
-    name: runner / black formatter
+    name: runner / black
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      # Install specific version black (this step is not required. default is "black[jupyter]")
-      - run: pip install black==23.1.0
-      - uses: reviewdog/action-black@v3
+      - uses: actions/checkout@v2
+      - name: Check files using the black formatter
+        uses: datadog/action-py-black-formatter@v2.1
+        id: action_black
+      - name: Annotate diff changes using reviewdog
+        if: steps.action_black.outputs.is_formatted == 'true'
+        uses: reviewdog/action-suggester@v1
         with:
-          github_token: ${{ secrets.TOKEN }}
-          # Change reviewdog reporter if you need [github-pr-check, github-check].
-          reporter: github-pr-check
-          # Change reporter level if you need.
-          # GitHub Status Check won't become failure with a warning.
-          level: warning
+          tool_name: blackfmt

--- a/test.py
+++ b/test.py
@@ -1,0 +1,20 @@
+import os, sys
+
+def func(a, b
+         ,c, d, e,
+         f,
+         ):
+    pass
+
+a= 1+2
+b = 1 + 2
+c =1 +2
+d =1+ 2
+e=1 +2
+f= 1+2
+
+l = [i 
+     for i 
+     in range(10)]
+
+print(l)

--- a/test.py
+++ b/test.py
@@ -1,20 +1,24 @@
 import os, sys
 
-def func(a, b
-         ,c, d, e,
-         f,
-         ):
+
+def func(
+    a,
+    b,
+    c,
+    d,
+    e,
+    f,
+):
     pass
 
-a= 1+2
-b = 1 + 2
-c =1 +2
-d =1+ 2
-e=1 +2
-f= 1+2
 
-l = [i 
-     for i 
-     in range(10)]
+a = 1 + 2
+b = 1 + 2
+c = 1 + 2
+d = 1 + 2
+e = 1 + 2
+f = 1 + 2
+
+l = [i for i in range(10)]
 
 print(l)

--- a/test.py
+++ b/test.py
@@ -1,24 +1,20 @@
 import os, sys
 
-
-def func(
-    a,
-    b,
-    c,
-    d,
-    e,
-    f,
-):
+def func(a, b
+         ,c, d, e,
+         f,
+         ):
     pass
 
-
-a = 1 + 2
+a= 1+2
 b = 1 + 2
-c = 1 + 2
-d = 1 + 2
-e = 1 + 2
-f = 1 + 2
+c =1 +2
+d =1+ 2
+e=1 +2
+f= 1+2
 
-l = [i for i in range(10)]
+l = [i 
+     for i 
+     in range(10)]
 
 print(l)

--- a/test33.py
+++ b/test33.py
@@ -1,0 +1,20 @@
+import os, sys
+
+def func(a, b
+         ,c, d, e,
+         f,
+         ):
+    pass
+
+a= 1+2
+b = 1 + 2
+c =1 +2
+d =1+ 2
+e=1 +2
+f= 1+2
+
+l = [i 
+     for i 
+     in range(10)]
+
+print(l)

--- a/test33.py
+++ b/test33.py
@@ -1,20 +1,24 @@
 import os, sys
 
-def func(a, b
-         ,c, d, e,
-         f,
-         ):
+
+def func(
+    a,
+    b,
+    c,
+    d,
+    e,
+    f,
+):
     pass
 
-a= 1+2
-b = 1 + 2
-c =1 +2
-d =1+ 2
-e=1 +2
-f= 1+2
 
-l = [i 
-     for i 
-     in range(10)]
+a = 1 + 2
+b = 1 + 2
+c = 1 + 2
+d = 1 + 2
+e = 1 + 2
+f = 1 + 2
+
+l = [i for i in range(10)]
 
 print(l)


### PR DESCRIPTION
There appear to be some python formatting errors in b709a9660ef8d4e7e95278e1176ab7a72f8bdcac. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.