### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,20 +1,24 @@
 import os, sys
 
-def func(a, b
-         ,c, d, e,
-         f,
-         ):
+
+def func(
+    a,
+    b,
+    c,
+    d,
+    e,
+    f,
+):
     pass
 
-a= 1+2
-b = 1 + 2
-c =1 +2
-d =1+ 2
-e=1 +2
-f= 1+2
 
-l = [i 
-     for i 
-     in range(10)]
+a = 1 + 2
+b = 1 + 2
+c = 1 + 2
+d = 1 + 2
+e = 1 + 2
+f = 1 + 2
+
+l = [i for i in range(10)]
 
 print(l)


### PR DESCRIPTION
There appear to be some python formatting errors in a8bcd41938139efefba6f472afa5df2053606bb3. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.