### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/test3344.py
+++ b/test3344.py
@@ -1,20 +1,24 @@
 import os, sys
 
-def func(a, b
-         ,c, d, e,
-         f,
-         ):
+
+def func(
+    a,
+    b,
+    c,
+    d,
+    e,
+    f,
+):
     pass
 
-a= 1+2
-b = 1 + 2
-c =1 +2
-d =1+ 2
-e=1 +2
-f= 1+2
 
-l = [i 
-     for i 
-     in range(10)]
+a = 1 + 2
+b = 1 + 2
+c = 1 + 2
+d = 1 + 2
+e = 1 + 2
+f = 1 + 2
+
+l = [i for i in range(10)]
 
 print(l)


### PR DESCRIPTION
There appear to be some python formatting errors in 1494b36ec37be82e0cd697af2fc86aa2eca45117. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.